### PR TITLE
actions: update install-guix-action to 1.5

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2.3.4
 
       - name: Install Guix
-        uses: PromyLOPh/guix-install-action@v1.4
+        uses: PromyLOPh/guix-install-action@v1.5
 
       - name: Import GPG key
         uses: crazy-max/ghaction-import-gpg@v4


### PR DESCRIPTION
GitHub broke the GitHub hosted guix mirror.  There's probably a ton of different downstream effects of this since Gnu/Savannah already doesn't like GitHub.  But hopefully, this gets builds running again.